### PR TITLE
post-release adjustments

### DIFF
--- a/project-space-pirates/levels/level_1.gd
+++ b/project-space-pirates/levels/level_1.gd
@@ -12,6 +12,9 @@ func _process(delta: float) -> void:
 		$Level1BGM.stop()
 		$InvisiWall/CollisionShape2D.set_deferred("disabled", false)
 	if SceneManager.escape_seq_active:
+		# Disables collision for the exit
+		$InvisiWallRight/CollisionShape2D.set_deferred("disabled", true)
+		
 		# Changes screens
 		$Screens/TL/ScreenTL.color = Color(1, 0, 0) # To red
 		$Screens/TM/ScreenTM.color = Color(1, 0, 0)

--- a/project-space-pirates/levels/level_1.tscn
+++ b/project-space-pirates/levels/level_1.tscn
@@ -449,6 +449,13 @@ position = Vector2(-4, -388)
 shape = SubResource("RectangleShape2D_4knja")
 disabled = true
 
+[node name="InvisiWallRight" type="StaticBody2D" parent="."]
+position = Vector2(5883, 3754)
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="InvisiWallRight"]
+position = Vector2(-4, -388)
+shape = SubResource("RectangleShape2D_4knja")
+
 [node name="Platforms" type="Node" parent="."]
 
 [node name="Platform" parent="Platforms" instance=ExtResource("5_n46q3")]

--- a/project-space-pirates/levels/level_2.gd
+++ b/project-space-pirates/levels/level_2.gd
@@ -7,6 +7,7 @@ var color_increment: float = 1
 func _ready() -> void:
 	$Timer.start()
 	$Control/CanvasLayer/TimerLabel.text = "Time left: %d" % countdown
+	$"Doors That Dont Open/FakeDoor/Sprite2D".modulate = Color(0.59, 0.147, 0.147)
 
 
 func _on_timer_timeout() -> void:

--- a/project-space-pirates/levels/level_2.tscn
+++ b/project-space-pirates/levels/level_2.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=23 format=3 uid="uid://cdmp8ry4bd76d"]
+[gd_scene load_steps=24 format=3 uid="uid://cdmp8ry4bd76d"]
 
 [ext_resource type="Script" uid="uid://stju4lg1eawp" path="res://levels/level_2.gd" id="1_ep78u"]
 [ext_resource type="PackedScene" uid="uid://bacqw7l3u02n6" path="res://objects/level_objects/platform.tscn" id="1_mi4ay"]
@@ -13,6 +13,7 @@
 [ext_resource type="PackedScene" uid="uid://dc87e8bajv67w" path="res://objects/level_objects/checkpoint_area.tscn" id="6_ilhis"]
 [ext_resource type="AudioStream" uid="uid://c5hdp7ex12hct" path="res://assets/music/The Great Escape Level 2.wav" id="9_at1ld"]
 [ext_resource type="PackedScene" uid="uid://bgu7u2465aw55" path="res://objects/level_objects/player_ship_static.tscn" id="9_sd18g"]
+[ext_resource type="PackedScene" uid="uid://df4phoxqoox8e" path="res://objects/enemies/PirateEnemy/pirate_actor.tscn" id="14_5orea"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_hbb88"]
 size = Vector2(16, 95)
@@ -91,6 +92,10 @@ texture_repeat = 2
 position = Vector2(6, 2)
 texture = ExtResource("5_5orea")
 polygon = PackedVector2Array(1863, 370, 1866, 294, 2016, 244, 2276, 197, 2645, 181, 3233, 235, 3569, 273, 4321, 275, 4543, 293, 5241, 325, 5336, 690, 5383, 1641, 5714, 2382, 5714, 2822, 7762, 2814, 7762, 2638, 8122, 2606, 8122, 3880, 8113, 5185, 7145, 5180, 6563, 5170, 5903, 5180, 4710, 5189, 2770, 5167, 1493, 5153, 37, 5153, -7, 1344, 84, 742, 837, 636, 1397, 593, 1901, 594, 1869, 533)
+
+[node name="Polygon2D" type="Polygon2D" parent="."]
+color = Color(0.0392157, 0.0117647, 0.00784314, 0.858824)
+polygon = PackedVector2Array(6772, 4335, 7232, 4335, 7232, 4208, 6772, 4209)
 
 [node name="LandingPand" type="Polygon2D" parent="."]
 texture_repeat = 2
@@ -396,6 +401,16 @@ libraries = {
 &"": SubResource("AnimationLibrary_0ourt")
 }
 autoplay = "red warning"
+
+[node name="PirateActor" parent="." instance=ExtResource("14_5orea")]
+position = Vector2(6736, 4268)
+move_speed = 30.0
+is_frozen = false
+
+[node name="PirateActor2" parent="." instance=ExtResource("14_5orea")]
+position = Vector2(6659, 4268)
+move_speed = 200.0
+is_frozen = false
 
 [connection signal="timeout" from="Timer" to="." method="_on_timer_timeout"]
 

--- a/project-space-pirates/objects/player/PlayerPlatformer/player_platformer.gd
+++ b/project-space-pirates/objects/player/PlayerPlatformer/player_platformer.gd
@@ -179,20 +179,6 @@ func i_frames(duration) -> void:
 	await get_tree().create_timer(duration).timeout
 	is_invincible = false
 
-# NOTE: Currently unused.
-func i_frames_effect() -> void:
-	$AnimatedSprite2D.visible = false
-	await get_tree().create_timer(0.2).timeout
-	$AnimatedSprite2D.visible = true
-	await get_tree().create_timer(0.2).timeout
-	$AnimatedSprite2D.visible = false
-	await get_tree().create_timer(0.2).timeout
-	$AnimatedSprite2D.visible = true
-	await get_tree().create_timer(0.2).timeout
-	$AnimatedSprite2D.visible = false
-	await get_tree().create_timer(0.2).timeout
-	$AnimatedSprite2D.visible = true
-
 
 func restore_health(health) -> void:
 	PlayerVariables.health += health

--- a/project-space-pirates/objects/player/PlayerPlatformer/player_platformer.tscn
+++ b/project-space-pirates/objects/player/PlayerPlatformer/player_platformer.tscn
@@ -230,7 +230,7 @@ wait_time = 0.2
 one_shot = true
 
 [node name="RechargeTimer" type="Timer" parent="."]
-wait_time = 3.0
+wait_time = 1.2
 one_shot = true
 
 [node name="CanvasLayer" type="CanvasLayer" parent="."]
@@ -267,9 +267,6 @@ offset_right = 191.0
 offset_bottom = 128.0
 text = "Recharging... 100%"
 label_settings = SubResource("LabelSettings_e3i7r")
-
-[node name="GPUParticles2D" type="GPUParticles2D" parent="."]
-visible = false
 
 [node name="Sounds" type="Node2D" parent="."]
 


### PR DESCRIPTION
Added:
+ Missing collision to boss arena

Changed:
* Reduced time until recharge begins to 1.2s (down from 3.0s)
* Added extra indicators to Escape level to help show which direction the player should move in

Removed:
- unused code
- unused nodes from player